### PR TITLE
fix(converter): use dynamic import for pdfjs-dist to fix ESM startup failure

### DIFF
--- a/src/converter/pdf.ts
+++ b/src/converter/pdf.ts
@@ -1,4 +1,3 @@
-import { getDocument } from 'pdfjs-dist/legacy/build/pdf.js'
 import type { Converter, ConvertResult } from './types.js'
 
 /**
@@ -10,6 +9,10 @@ import type { Converter, ConvertResult } from './types.js'
  */
 
 export const pdfConverter: Converter = async (_filePath, data): Promise<ConvertResult> => {
+  // Dynamic import: pdfjs-dist/legacy is CommonJS and cannot be named-imported
+  // from ESM under Node.js (Named export 'getDocument' not found). Matches the
+  // pattern already used in ocr.ts.
+  const { getDocument } = await import('pdfjs-dist/legacy/build/pdf.js')
   const task = getDocument({
     data: new Uint8Array(data),
     isEvalSupported: false,


### PR DESCRIPTION
## Problem

Installing this plugin breaks `dsh web` startup with:

```
SyntaxError: Named export 'getDocument' not found. The requested module
'pdfjs-dist/legacy/build/pdf.js' is a CommonJS module, which may not
support all module.exports as named exports.
```

Root cause: `src/converter/pdf.ts` named-imports `getDocument` from
`pdfjs-dist/legacy/build/pdf.js` at module top level. That module is
CommonJS, and Node.js ESM disallows named imports from CJS modules —
the error is thrown at plugin-load time, so the whole profile fails to
boot.

## Fix

Move the import inside `pdfConverter` as a dynamic `await import()`,
which is the pattern **already used in `src/converter/ocr.ts`** for the
same dependency. This restores startup and keeps PDF→Markdown working.

## Verification

- `tsc -p tsconfig.build.json --noEmit` ✅
- `npm run build` ✅
- With this change applied to the installed plugin, `dsh web` starts
  and PDF conversion still works.